### PR TITLE
Implement PublishPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,9 +335,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1024,8 +1037,13 @@ name = "rock-node-publish-plugin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dashmap",
+ "futures-util",
  "rock-node-core",
+ "rock-node-protobufs",
  "tokio",
+ "tokio-stream",
+ "tonic",
  "tracing",
  "uuid",
 ]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 <div align="center">
   <img src="assets/logo.jpeg" alt="Rock Node Logo" width="300"/>
   
+  <p><em>Resilient as a Rock ⚡</em></p>
+  
   [![Rust Version](https://img.shields.io/badge/rust-1.75.0+-blue.svg)](https://www.rust-lang.org)
   [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 </div>

--- a/config/development.toml
+++ b/config/development.toml
@@ -14,6 +14,12 @@ database_path = "data/" # Use a local 'data' directory for development
     enabled = true
     listen_address = "0.0.0.0:9600"
 
+    [plugins.publish_service]
+    enabled = true
+    grpc_address = "0.0.0.0"
+    grpc_port = 8080
+    max_concurrent_streams = 250 
+
     [plugins.persistence]
     enabled = true
     hot_storage_path = "hot"

--- a/crates/rock-node-core/src/config.rs
+++ b/crates/rock-node-core/src/config.rs
@@ -17,6 +17,7 @@ pub struct PluginConfigs {
     pub observability: ObservabilityConfig,
     pub persistence: PersistenceConfig,
     pub subscribe_service: SubscribeServiceConfig,
+    pub publish_service: PublishServiceConfig,
     // Add other plugin configs here
 }
 
@@ -25,6 +26,14 @@ pub struct ObservabilityConfig {
     pub enabled: bool,
     pub listen_address: String, 
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PublishServiceConfig {
+    pub enabled: bool,
+    pub grpc_address: String,
+    pub grpc_port: u16,
+    pub max_concurrent_streams: usize,
+} 
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PersistenceConfig {

--- a/crates/rock-node-publish-plugin/Cargo.toml
+++ b/crates/rock-node-publish-plugin/Cargo.toml
@@ -1,11 +1,30 @@
+# File: rock-node-workspace/crates/rock-node-publish-plugin/Cargo.toml
+
 [package]
 name = "rock-node-publish-plugin"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rock-node-core = { path = "../rock-node-core" } 
+rock-node-core = { path = "../rock-node-core" }
+rock-node-protobufs = { path = "../rock-node-protobufs" }
+
+# Async runtime and utilities
 tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+futures-util = "0.3"
+
+# gRPC library
+tonic = "0.11"
+
+# For easy error handling
 anyhow = "1"
+
+# For logging
 tracing = "0.1"
-uuid = "1"
+
+# For unique session IDs
+uuid = { version = "1", features = ["v4"] }
+
+# For concurrent hash maps
+dashmap = "5.5"

--- a/crates/rock-node-publish-plugin/src/lib.rs
+++ b/crates/rock-node-publish-plugin/src/lib.rs
@@ -1,15 +1,20 @@
-// File: rock-node-workspace/crates/rock-node-publish-plugin/src/lib.rs
-// (Corrected Version)
+use rock_node_core::{app_context::AppContext, error::Result, plugin::Plugin};
+use rock_node_protobufs::org::hiero::block::api::block_stream_publish_service_server::BlockStreamPublishServiceServer;
+use state::SharedState;
+use std::any::TypeId;
+use std::sync::Arc;
+use tracing::{info, warn}; // <-- Import `warn` here
 
-use rock_node_core::{
-    app_context::AppContext,
-    error::Result,
-    events::{BlockData, BlockItemsReceived},
-    plugin::Plugin,
-};
-use std::time::Duration;
-use tokio::time::sleep;
-use tracing::info;
+mod service;
+mod session_manager;
+mod state;
+
+use service::PublishServiceImpl;
+
+// A trait needed for the startup logic. It should live in `rock-node-core` eventually.
+pub trait BlockReader: Send + Sync {
+    fn get_latest_persisted_block_number(&self) -> i64;
+}
 
 #[derive(Debug, Default)]
 pub struct PublishPlugin {
@@ -27,45 +32,65 @@ impl Plugin for PublishPlugin {
         "publish-plugin"
     }
 
+    // Return the correct `Result` type as defined by the trait
     fn initialize(&mut self, context: AppContext) -> Result<()> {
         self.context = Some(context);
         info!("PublishPlugin initialized.");
         Ok(())
     }
 
+    // Return the correct `Result` type as defined by the trait
     fn start(&mut self) -> Result<()> {
-        info!("Starting PublishPlugin...");
+        info!("Starting PublishPlugin gRPC Server...");
         let context = self.context.as_ref().unwrap().clone();
         
-        // This task simulates a new block being produced every 5 seconds.
+        let config = &self.context.as_ref().unwrap().config.plugins.publish_service;
+        if !config.enabled {
+            info!("PublishPlugin is disabled. Skipping start.");
+            return Ok(());
+        }
+        let grpc_address = config.grpc_address.clone();
+        let grpc_port = config.grpc_port;
+        let listen_address = format!("{}:{}", grpc_address, grpc_port);
+
+        let shared_state = Arc::new(SharedState::new());
+
+        // VERY TEMPORARY: Set the latest persisted block to -1 to start with a clean state.
+        shared_state.set_latest_persisted_block(-1);
+
+        let shared_state_clone = shared_state.clone();
+        let context_clone = context.clone();
         tokio::spawn(async move {
-            let mut block_number = 0;
-            loop {
-                sleep(Duration::from_secs(5)).await;
-                
-                let block_data = BlockData {
-                    block_number,
-                    contents: format!("This is the data for block #{}", block_number),
-                };
-                info!("Publishing new block: #{}", block_number);
-
-                // "Claim Check" Pattern: Store the data and get a key.
-                let cache_key = context.block_data_cache.insert(block_data);
-
-                // Publish the event with the claim check key.
-                let event = BlockItemsReceived {
-                    block_number,
-                    cache_key,
-                };
-                
-                if context.tx_block_items_received.send(event).await.is_err() {
-                    // This can happen if there are no subscribers, which is okay.
-                    // In a real app, we might log a warning here.
+            info!("Querying for latest persisted block number...");
+            let providers = context_clone.service_providers.read().await;
+            if let Some(provider) = providers.get(&TypeId::of::<Arc<dyn BlockReader>>()) {
+                if let Some(block_reader) = provider.downcast_ref::<Arc<dyn BlockReader>>() {
+                    let block_number = block_reader.get_latest_persisted_block_number();
+                    shared_state_clone.set_latest_persisted_block(block_number);
+                    info!("Set latest persisted block to: {}", block_number);
                 }
-                
-                block_number += 1;
+            } else {
+                warn!("No BlockReader provider found. Starting with clean state (block -1).");
             }
         });
+        
+        let service = PublishServiceImpl {
+            context,
+            shared_state,
+        };
+        let server = BlockStreamPublishServiceServer::new(service);
+
+        tokio::spawn(async move {
+            info!("Publish gRPC service listening on {}", listen_address);
+            tonic::transport::Server::builder()
+                .add_service(server)
+                .serve(listen_address.parse().unwrap())
+                .await
+                // Use map_err to convert the error type to our core::Error
+                .map_err(|e| rock_node_core::Error::Other(e.into()))
+                .unwrap();
+        });
+        
         Ok(())
     }
 }

--- a/crates/rock-node-publish-plugin/src/service.rs
+++ b/crates/rock-node-publish-plugin/src/service.rs
@@ -1,0 +1,57 @@
+use crate::{session_manager::SessionManager, state::SharedState};
+use rock_node_core::AppContext;
+use rock_node_protobufs::org::hiero::block::api::{
+    block_stream_publish_service_server::BlockStreamPublishService, PublishStreamRequest,
+    PublishStreamResponse,
+};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+use tracing::{info};
+
+/// Implements the gRPC service.
+#[derive(Debug)]
+pub struct PublishServiceImpl {
+    pub context: AppContext,
+    pub shared_state: Arc<SharedState>,
+}
+
+#[tonic::async_trait]
+impl BlockStreamPublishService for PublishServiceImpl {
+    type publishBlockStreamStream = ReceiverStream<Result<PublishStreamResponse, Status>>;
+
+    async fn publish_block_stream(
+        &self,
+        request: Request<tonic::Streaming<PublishStreamRequest>>,
+    ) -> Result<Response<Self::publishBlockStreamStream>, Status> {
+        let mut inbound_stream = request.into_inner();
+        let (response_tx, response_rx) = mpsc::channel(16);
+
+        // Create a new SessionManager to handle the state for this connection.
+        let mut session_manager = SessionManager::new(
+            self.context.clone(),
+            self.shared_state.clone(),
+            response_tx,
+        );
+        let session_id = session_manager.id;
+        info!(%session_id, "New publisher connection. Spawning handler task.");
+
+        // Spawn a new task that owns the stream and the session manager.
+        // This task will run the I/O loop.
+        tokio::spawn(async move {
+            while let Some(request_result) = inbound_stream.message().await.ok().flatten() {
+                if let Some(request_type) = request_result.request {
+                    // Call the session manager to handle the logic.
+                    if session_manager.handle_request(request_type).await {
+                        // The handler has decided the session should end.
+                        break;
+                    }
+                }
+            }
+            info!(%session_id, "Session handler task finished.");
+        });
+
+        Ok(Response::new(ReceiverStream::new(response_rx)))
+    }
+}

--- a/crates/rock-node-publish-plugin/src/session_manager.rs
+++ b/crates/rock-node-publish-plugin/src/session_manager.rs
@@ -1,0 +1,147 @@
+use crate::state::{SharedState, SessionState};
+use anyhow::Result;
+use rock_node_core::AppContext;
+use rock_node_protobufs::{
+    com::hedera::hapi::block::stream::block_item::Item as BlockItemType,
+    org::hiero::block::api::{
+        publish_stream_request::Request as PublishRequestType,
+        publish_stream_response, PublishStreamResponse,
+    },
+};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tonic::Status;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// Manages the state for a single, active publisher connection.
+pub struct SessionManager {
+    pub id: Uuid,
+    context: AppContext,
+    shared_state: Arc<SharedState>,
+    state: SessionState,
+    current_block_number: u64,
+    item_buffer: Vec<rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem>,
+    response_tx: mpsc::Sender<std::result::Result<PublishStreamResponse, Status>>,
+}
+
+impl SessionManager {
+    pub fn new(
+        context: AppContext,
+        shared_state: Arc<SharedState>,
+        response_tx: mpsc::Sender<Result<PublishStreamResponse, Status>>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            context,
+            shared_state,
+            state: SessionState::New,
+            current_block_number: 0,
+            item_buffer: Vec::new(),
+            response_tx,
+        }
+    }
+
+    /// Processes a single request from the client stream. Returns `true` if the session should end.
+    pub async fn handle_request(&mut self, request: PublishRequestType) -> bool {
+        match request {
+            PublishRequestType::BlockItems(block_item_set) => {
+                for item in block_item_set.block_items {
+                    if let Some(item_type) = &item.item {
+                        if let BlockItemType::BlockHeader(header) = item_type {
+                            if !self.handle_block_header(header.number as i64).await {
+                                return true; // Handshake failed, end session.
+                            }
+                        }
+                    }
+
+                    if self.state == SessionState::Primary {
+                        self.item_buffer.push(item.clone());
+                    }
+
+                    if let Some(BlockItemType::BlockProof(_)) = &item.item {
+                        if self.state == SessionState::Primary {
+                            self.publish_complete_block().await;
+                            return true; // End session after successfully publishing a block.
+                        }
+                    }
+                }
+            }
+            PublishRequestType::EndStream(_) => {
+                info!(session_id = %self.id, "Publisher sent EndStream. Closing connection.");
+                return true; // Exit the loop
+            }
+        }
+        false
+    }
+
+    async fn handle_block_header(&mut self, block_number: i64) -> bool {
+        self.current_block_number = block_number as u64;
+        self.state = SessionState::New;
+        self.item_buffer.clear();   
+
+        let latest_persisted = self.shared_state.get_latest_persisted_block();
+        if block_number <= latest_persisted {
+            warn!(session_id = %self.id, block_number, latest_persisted, "Received duplicate block. Rejecting.");
+            let code = publish_stream_response::end_of_stream::Code::DuplicateBlock;
+            self.send_response(response_from_code(code, latest_persisted as u64)).await;
+            return false;
+        }
+
+        let winner_entry = self.shared_state.block_winners.entry(block_number as u64).or_insert(self.id);
+        if *winner_entry == self.id {
+            self.state = SessionState::Primary;
+            info!(session_id = %self.id, block_number, "This session is now PRIMARY.");
+        } else {
+            self.state = SessionState::Behind;
+            info!(session_id = %self.id, block_number, "Another session is primary. Sending SkipBlock.");
+            self.send_skip_block().await;
+        }
+        true
+    }
+
+    async fn publish_complete_block(&mut self) {
+        info!(session_id = %self.id, block_number = self.current_block_number, "Block is complete. Publishing to core.");
+        let block_data = rock_node_core::events::BlockData {
+            block_number: self.current_block_number,
+            contents: format!("Real data for block #{}. Contains {} items.", self.current_block_number, self.item_buffer.len()),
+        };
+        let cache_key = self.context.block_data_cache.insert(block_data);
+        let event = rock_node_core::events::BlockItemsReceived {
+            block_number: self.current_block_number,
+            cache_key,
+        };
+        if self.context.tx_block_items_received.send(event).await.is_err() {
+            warn!(session_id = %self.id, "Failed to publish BlockItemsReceived event.");
+        }
+        self.item_buffer.clear();
+    }
+
+    async fn send_skip_block(&self) {
+        let response = PublishStreamResponse {
+            response: Some(publish_stream_response::Response::SkipBlock(
+                publish_stream_response::SkipBlock {
+                    block_number: self.current_block_number,
+                },
+            )),
+        };
+        self.send_response(response).await;
+    }
+
+    async fn send_response(&self, response: PublishStreamResponse) {
+        if self.response_tx.send(Ok(response)).await.is_err() {
+            warn!(session_id = %self.id, "Failed to send response to client. Connection may be closed.");
+        }
+    }
+}
+
+fn response_from_code(code: publish_stream_response::end_of_stream::Code, block_number: u64) -> PublishStreamResponse {
+    PublishStreamResponse {
+        response: Some(publish_stream_response::Response::EndStream(
+            publish_stream_response::EndOfStream {
+                status: code.into(),
+                block_number,
+            },
+        )),
+    }
+}

--- a/crates/rock-node-publish-plugin/src/state.rs
+++ b/crates/rock-node-publish-plugin/src/state.rs
@@ -1,0 +1,43 @@
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use dashmap::DashMap;
+use uuid::Uuid;
+
+/// The state of a single publisher session in the block race.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionState {
+    /// The session has just connected and is competing to be primary.
+    New,
+    /// This session "won" the race and is sending the block data.
+    Primary,
+    /// This session "lost" the race and has been told to skip this block.
+    Behind,
+}
+
+/// The central, shared state for the entire Publish Plugin.
+/// It's wrapped in an Arc to be shared safely across all session tasks.
+#[derive(Debug)]
+pub struct SharedState {
+    /// Maps a block number to the ID of the session that "won" the race for it.
+    pub block_winners: DashMap<u64, Uuid>,
+    /// The latest block number that has been confirmed as persisted by the system.
+    /// We use an AtomicU64 for safe concurrent reads from many session tasks.
+    pub latest_persisted_block: AtomicI64,
+}
+
+impl SharedState {
+    pub fn new() -> Self {
+        Self {
+            block_winners: DashMap::new(),
+            // u64::MAX is used to represent -1, for a clean state before genesis block 0.
+            latest_persisted_block: AtomicI64::new(-1),
+        }
+    }
+
+    pub fn get_latest_persisted_block(&self) -> i64 {
+        self.latest_persisted_block.load(Ordering::Relaxed)
+    }
+
+    pub fn set_latest_persisted_block(&self, block_number: i64) {
+        self.latest_persisted_block.store(block_number, Ordering::Relaxed);
+    }
+}


### PR DESCRIPTION
### Description

This PR implements a real PublishPlugin implementation, by creating a grpc server using configuration and appropariate service. It also sets the foundation for multiple publisher support, where publishers are racing.

### Related Issues

- Closes #21 

---
### Changes

- session_manager.rs responsible for each session management. Each session is a new publisher.
- service.rs responsible to assign the manager for each new connection.
- state.rs which all sessions use to and share.

### Reviewer Checklist

- [x] The code follows the project's coding standards.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added necessary documentation (if applicable).
- [ ] I have confirmed that this change does not introduce any new security vulnerabilities.
