### PR TITLE
Add Protobuf Documentation

### DIFF
--- a/docs/protobufs/protobufs-compilation.md
+++ b/docs/protobufs/protobufs-compilation.md
@@ -1,0 +1,147 @@
+# Protobufs Compilation and Generation Design
+
+**Version:** 1.0
+**Date:** June 13, 2025
+**Status:** Final
+
+---
+
+## 1. Introduction
+
+This document details the architecture and process for compiling and generating Rust code from Protocol Buffer (Protobuf) definition files within the `rock-node-protobufs` crate. This crate serves as the single source of truth for all Protobuf-derived types and gRPC service definitions used throughout the Rock Node project, encompassing both our custom definitions and those imported from external dependencies like the Hiero Consensus Node.
+
+The primary goals of this setup are to:
+
+- Centralize all Protobuf definitions and generated code.
+- Ensure consistency across the project regarding data structures and service interfaces.
+- Automate the code-generation process to minimize manual effort and reduce errors.
+- Manage external Protobuf dependencies cleanly.
+
+---
+
+## 2. Overview of Protobuf Generation in Rust
+
+In a Rust project, Protobuf definitions (`.proto` files) are typically compiled into native Rust structs and gRPC service traits using build scripts. The `tonic` and `prost` crates are instrumental in this process:
+
+- **prost** – Provides a Protocol Buffers implementation for Rust. It handles the serialization/deserialization of Protobuf messages and generates basic Rust structs from `.proto` files.  
+- **tonic** – A gRPC implementation for Rust, built on `prost` and `tokio`. It extends `prost`'s capabilities to generate gRPC client and server code (traits, messages, and stubs).  
+- **tonic-build** – A `build.rs` helper crate for `tonic` that orchestrates the compilation of `.proto` files into Rust code during the crate's build process.  
+
+---
+
+## 3. `rock-node-protobufs/Cargo.toml` – Dependencies and Build Configuration
+
+The `Cargo.toml` file in `rock-node-protobufs` defines the runtime dependencies for the generated code and the build-time dependencies required by the `build.rs` script.
+
+### Key Sections
+
+```toml
+[dependencies]
+# Runtime dependencies
+tonic  = "..."
+prost  = "..."
+serde  = { version = "...", features = ["derive"] }
+
+[build-dependencies]
+# Build-time dependencies
+tonic-build = "..."
+anyhow      = "..."
+walkdir     = "..."
+fs_extra    = "..."
+```
+
+Explanation:
+
+- `tonic` and `prost`: Runtime dependencies because the generated Rust code relies on their traits and types for message encoding/decoding and gRPC communication.  
+- `serde`: Ensures that all generated Protobuf structs automatically derive `Serialize` and `Deserialize`. This significantly simplifies integration with other Rust serialization mechanisms (e.g., JSON, YAML).  
+- `tonic-build`: Primary tool for compiling `.proto` files into Rust code.  
+- `anyhow`: Simplified error handling within the `build.rs` script.  
+- `walkdir`: Recursively traverses directories to find all `.proto` files.  
+- `fs_extra`: Provides utilities for filesystem operations, specifically copying directories.  
+
+---
+
+## 4. `rock-node-protobufs/build.rs` – The Code-Generation Orchestrator
+
+The `build.rs` script is executed by Cargo before the `rock-node-protobufs` crate itself is compiled. Its responsibility is to prepare the environment and invoke `tonic-build` to generate the Rust source files.
+
+### Detailed Breakdown of `build.rs` Logic
+
+**Path Resolution**
+
+The script first determines the necessary file paths:
+
+1. The root of the `rock-node-protobufs` crate and the entire rock-node workspace.  
+2. The directory where our project's custom `.proto` files are located.  
+3. Cargo's temporary output directory where generated files will be placed.  
+4. A `unified_proto_dir`: a critical temporary sub-directory where all `.proto` files (both local and external) are aggregated before compilation. This unified location allows `tonic-build` to correctly resolve imports across different original source locations.  
+
+**Ensure Idempotency**
+
+Before each build, the `unified_proto_dir` is completely removed and then recreated. This guarantees that the build is always clean and consistent, preventing issues from stale or leftover files from previous runs.
+
+**Change Detection**
+
+The script instructs Cargo to re-run itself if any file within our local protobufs directory changes. This optimizes builds by avoiding unnecessary recompilations.
+
+**Copying Local Protobufs**
+
+Our own `.proto` files are copied into the `unified_proto_dir`—these are the first set of protobuf definitions to be compiled.
+
+**Handling External Protobuf Dependencies (Hiero Consensus Node)**
+
+- Checks if the `hiero-consensus-node` Git repository (which contains Hedera's official protobuf definitions) has already been cloned into a temporary directory.  
+- If not, performs a shallow sparse clone:  
+  ```bash
+  git clone --depth=1 --filter=blob:none --sparse <repo-url> <tmp-dir>
+  ```  
+- Uses `git sparse-checkout set` to check out only the specific sub-directory containing the required `.proto` files.  
+- Pins the repository to a specific commit hash to guarantee reproducible builds.  
+- Copies only the necessary subdirectories into the `unified_proto_dir`, preventing compilation of irrelevant or internal protobufs.
+
+**Discovering All Protobuf Files**
+
+The script recursively finds all `.proto` files within the `unified_proto_dir`. If no files are found, the build fails, signaling a setup issue.
+
+**Compiling Protobufs with `tonic-build`**
+
+1. Calls `tonic_build::configure()` to set up compilation parameters.  
+2. Applies `#[derive(serde::Serialize, serde::Deserialize)]` to every generated Rust struct, enabling seamless conversion to/from formats like JSON.  
+3. Invokes `compile()` with the list of discovered `.proto` files and the `unified_proto_dir` as the include path—this allows `tonic-build` to resolve inter-file imports.
+
+---
+
+## 5. `rock-node-protobufs/src/lib.rs` – The Generated Code Interface
+
+The `src/lib.rs` file acts as the public interface to the generated Protobuf code. It uses the `tonic::include_proto!` macro to bring the compiled Rust modules into scope.
+
+```rust
+#![allow(non_camel_case_types)] // Suppress Clippy warnings derived from proto naming
+
+tonic::include_proto!("org.hiero.block.api");
+// Additional include_proto! calls as needed...
+```
+
+Key points:
+
+- `#![allow(non_camel_case_types)]`: Protobuf naming conventions (e.g., `snake_case` fields within `CamelCase` messages) often clash with Rust's lints. This attribute disables warnings specifically in the generated code, which we do not control.  
+- `tonic::include_proto!("…")`: Incorporates the generated code for the given Protobuf package. For example, `org.hiero.block.api` becomes accessible at `rock_node_protobufs::org::hiero::block::api::BlockHeader`.  
+- A `pub mod proto` is also included for custom `.proto` files that do not fall under the `org.hiero` or `com.hedera` namespaces.
+
+---
+
+## 6. Summary & Benefits
+
+This robust Protobuf compilation and generation strategy offers several significant benefits:
+
+1. **Centralized Definitions** – All `.proto` files, whether internal or external, are managed within a single `rock-node-protobufs` crate, simplifying dependency management for other crates.  
+2. **Automated Code Generation** – The `build.rs` script fully automates the process of fetching external protobufs, aggregating them, and compiling them into Rust code, reducing manual effort and potential errors.  
+3. **Version Control for External Dependencies** – Pinning the `hiero-consensus-node` repository to a specific commit hash ensures build reproducibility and stability.  
+4. **Optimized External Fetching** – Using `git clone --sparse` significantly reduces the amount of data downloaded from external repositories, making builds faster and more efficient.  
+5. **Seamless `serde` Integration** – Automatic derivation of `Serialize` and `Deserialize` on all generated types enhances interoperability with Rust's broader serialization ecosystem.  
+6. **Clear Module Structure** – The Rust module hierarchy mirrors the Protobuf package structure, leading to intuitive code navigation and usage.  
+7. **Idempotent Builds** – The `build.rs` script is designed to be idempotent, ensuring a consistent build environment across different machines and successive builds.
+
+---
+
+> This setup provides a reliable foundation for working with Protobufs and gRPC services throughout the Rock Node project.


### PR DESCRIPTION
### Description

This PR adds documentation around the protobufs, explaining the gathering, generation and usage.

### Related Issues

- Closes #33 

---
### Changes

- Adds new document.

### Reviewer Checklist

- [ ] The code follows the project's coding standards.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added necessary documentation (if applicable).
- [ ] I have confirmed that this change does not introduce any new security vulnerabilities.
