### PR TITLE
test: block access and server status E2E tests

### DIFF
--- a/tests/e2e/src/common.rs
+++ b/tests/e2e/src/common.rs
@@ -94,6 +94,8 @@ impl TestContext {
             .with_exposed_port(8080.tcp())
             .with_exposed_port(50051.tcp())
             .with_exposed_port(50052.tcp())
+            .with_exposed_port(50053.tcp())
+            .with_exposed_port(50054.tcp())
             .with_wait_for(WaitFor::message_on_stdout(
                 "Rock Node running successfully.",
             ))
@@ -134,7 +136,6 @@ impl TestContext {
         Ok(BlockStreamPublishServiceClient::new(channel))
     }
 
-    // SECOND_EDIT: add subscriber_client helper
     /// Returns a gRPC client for the `BlockStreamSubscribeService` running inside the
     /// Rock-Node container.
     pub async fn subscriber_client(&self) -> Result<BlockStreamSubscribeServiceClient<Channel>> {
@@ -142,6 +143,24 @@ impl TestContext {
         let endpoint = format!("http://localhost:{}", port);
         let channel = Channel::from_shared(endpoint)?.connect().await?;
         Ok(BlockStreamSubscribeServiceClient::new(channel))
+    }
+
+    /// Returns a gRPC client for the `BlockNodeService` (Server Status) running inside the
+    /// Rock-Node container.
+    pub async fn status_client(&self) -> Result<rock_node_protobufs::org::hiero::block::api::block_node_service_client::BlockNodeServiceClient<Channel>>{
+        let port = self.container.get_host_port_ipv4(50054).await?;
+        let endpoint = format!("http://localhost:{}", port);
+        let channel = Channel::from_shared(endpoint)?.connect().await?;
+        Ok(rock_node_protobufs::org::hiero::block::api::block_node_service_client::BlockNodeServiceClient::new(channel))
+    }
+
+    /// Returns a gRPC client for the `BlockAccessService` running inside the
+    /// Rock-Node container.
+    pub async fn access_client(&self) -> Result<rock_node_protobufs::org::hiero::block::api::block_access_service_client::BlockAccessServiceClient<Channel>>{
+        let port = self.container.get_host_port_ipv4(50053).await?;
+        let endpoint = format!("http://localhost:{}", port);
+        let channel = Channel::from_shared(endpoint)?.connect().await?;
+        Ok(rock_node_protobufs::org::hiero::block::api::block_access_service_client::BlockAccessServiceClient::new(channel))
     }
 }
 

--- a/tests/e2e/src/tests/block_access_suite.rs
+++ b/tests/e2e/src/tests/block_access_suite.rs
@@ -1,0 +1,67 @@
+use crate::common::{publish_blocks, TestContext};
+use anyhow::Result;
+use rock_node_protobufs::org::hiero::block::api::{
+    block_request::BlockSpecifier, block_response, BlockRequest,
+};
+use serial_test::serial;
+
+/// Test Case: Get Existing Block
+///
+/// Objective: Verify that a client can fetch a specific, single historical
+/// block by its number.
+#[tokio::test]
+#[serial]
+async fn test_get_block_by_number_successfully() -> Result<()> {
+    let ctx = TestContext::new().await?;
+    publish_blocks(&ctx, 0, 5).await?;
+    let mut access_client = ctx.access_client().await?;
+
+    let request = BlockRequest {
+        block_specifier: Some(BlockSpecifier::BlockNumber(3)),
+    };
+    let response = access_client.get_block(request).await?.into_inner();
+
+    assert_eq!(
+        response.status,
+        block_response::Code::Success as i32,
+        "Response status should be SUCCESS",
+    );
+
+    let block = response.block.expect("Response should contain a block");
+
+    let header = block.items.iter().find_map(|item| match &item.item {
+        Some(rock_node_protobufs::com::hedera::hapi::block::stream::block_item::Item::BlockHeader(h)) => Some(h),
+        _ => None,
+    }).expect("Returned block must have a header");
+
+    assert_eq!(header.number, 3, "Returned block has the wrong number");
+    Ok(())
+}
+
+/// Test Case: Get Non-Existent Block
+///
+/// Objective: Verify that requesting a block that has not been published
+/// results in a NOT_AVAILABLE status.
+#[tokio::test]
+#[serial]
+async fn test_get_non_existent_block() -> Result<()> {
+    let ctx = TestContext::new().await?;
+    publish_blocks(&ctx, 0, 5).await?;
+    let mut access_client = ctx.access_client().await?;
+
+    let request = BlockRequest {
+        block_specifier: Some(BlockSpecifier::BlockNumber(10)),
+    };
+    let response = access_client.get_block(request).await?.into_inner();
+    println!("Response: {:?}", response);
+    assert_eq!(
+        response.status,
+        block_response::Code::NotAvailable as i32,
+        "Response status should be NOT_AVAILABLE",
+    );
+    assert!(
+        response.block.is_none(),
+        "Response should not contain a block"
+    );
+    Ok(())
+}

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -1,3 +1,5 @@
+pub mod block_access_suite;
 pub mod health_check;
 pub mod ingestion_suite;
+pub mod server_status_suite;
 pub mod subscription_suite;

--- a/tests/e2e/src/tests/server_status_suite.rs
+++ b/tests/e2e/src/tests/server_status_suite.rs
@@ -1,0 +1,29 @@
+use crate::common::{publish_blocks, TestContext};
+use anyhow::Result;
+use rock_node_protobufs::org::hiero::block::api::ServerStatusRequest;
+use serial_test::serial;
+
+/// Test Case: Server Status
+///
+/// Objective: Verify that the `server_status` endpoint correctly reports the
+/// first and last available block numbers after data has been persisted.
+#[tokio::test]
+#[serial]
+async fn test_server_status_returns_correct_block_range() -> Result<()> {
+    let ctx = TestContext::new().await?;
+    publish_blocks(&ctx, 0, 30).await?;
+    let mut status_client = ctx.status_client().await?;
+
+    let request = ServerStatusRequest::default();
+    let response = status_client.server_status(request).await?.into_inner();
+
+    assert_eq!(
+        response.first_available_block, 0,
+        "First available block is incorrect",
+    );
+    assert_eq!(
+        response.last_available_block, 30,
+        "Last available block is incorrect",
+    );
+    Ok(())
+}


### PR DESCRIPTION
### Description

This PR adds new E2E tests for Block Access and Server Status API

### Related Issues

- Closes #83 

### Reviewer Checklist

- [x] The code follows the project's coding standards.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have added necessary documentation (if applicable).
- [x] I have confirmed that this change does not introduce any new security vulnerabilities.
