### PR TITLE
feat: update to latest protobuf changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,7 +2496,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "prost",
  "rock-node-core",
+ "rock-node-protobufs",
  "tokio",
  "tracing",
  "uuid",

--- a/crates/rock-node-backfill-plugin/examples/backfill_continious_mode.rs
+++ b/crates/rock-node-backfill-plugin/examples/backfill_continious_mode.rs
@@ -125,6 +125,7 @@ async fn main() -> Result<()> {
     let (tx_persisted, _) = broadcast::channel(1);
     let (tx_items, _) = mpsc::channel(1);
     let (tx_verified, _) = mpsc::channel(1);
+    let (tx_verification_failed, _) = broadcast::channel(1);
     let app_context = AppContext {
         config: Arc::new(config),
         metrics: Arc::new(create_isolated_metrics()),
@@ -133,6 +134,7 @@ async fn main() -> Result<()> {
         block_data_cache: Arc::new(Default::default()),
         tx_block_items_received: tx_items,
         tx_block_verified: tx_verified,
+        tx_block_verification_failed: tx_verification_failed,
         tx_block_persisted: tx_persisted,
     };
 

--- a/crates/rock-node-backfill-plugin/src/lib.rs
+++ b/crates/rock-node-backfill-plugin/src/lib.rs
@@ -216,6 +216,7 @@ mod tests {
             block_data_cache: Arc::new(create_test_cache()),
             tx_block_items_received: tokio::sync::mpsc::channel(100).0,
             tx_block_verified: tokio::sync::mpsc::channel(100).0,
+            tx_block_verification_failed: tokio::sync::broadcast::channel(100).0,
             tx_block_persisted: tokio::sync::broadcast::channel(100).0,
         };
 

--- a/crates/rock-node-block-access-plugin/src/lib.rs
+++ b/crates/rock-node-block-access-plugin/src/lib.rs
@@ -175,6 +175,7 @@ mod tests {
             block_data_cache: Arc::new(Default::default()),
             tx_block_items_received: tokio::sync::mpsc::channel(100).0,
             tx_block_verified: tokio::sync::mpsc::channel(100).0,
+            tx_block_verification_failed: tokio::sync::broadcast::channel(100).0,
             tx_block_persisted: tokio::sync::broadcast::channel(100).0,
         }
     }

--- a/crates/rock-node-core/src/app_context.rs
+++ b/crates/rock-node-core/src/app_context.rs
@@ -18,6 +18,9 @@ pub struct AppContext {
     // Can be mpsc as it's a 1-to-1 pipeline step
     pub tx_block_verified: mpsc::Sender<super::events::BlockVerified>,
 
+    // MUST be broadcast as multiple publisher sessions need to know about verification failures
+    pub tx_block_verification_failed: broadcast::Sender<super::events::BlockVerificationFailed>,
+
     // MUST be broadcast to allow multiple concurrent sessions to wait for their specific ACKs
     pub tx_block_persisted: broadcast::Sender<super::events::BlockPersisted>,
 }
@@ -61,6 +64,7 @@ mod tests {
 
         let (tx_block_items_received, _rx) = mpsc::channel(100);
         let (tx_block_verified, _rx) = mpsc::channel(100);
+        let (tx_block_verification_failed, _rx) = broadcast::channel(100);
         let (tx_block_persisted, _rx) = broadcast::channel(100);
 
         AppContext {
@@ -71,6 +75,7 @@ mod tests {
             block_data_cache,
             tx_block_items_received,
             tx_block_verified,
+            tx_block_verification_failed,
             tx_block_persisted,
         }
     }
@@ -113,6 +118,7 @@ mod tests {
 
         let (tx_block_items_received, mut rx_block_items_received) = mpsc::channel(100);
         let (tx_block_verified, _rx) = mpsc::channel(100);
+        let (tx_block_verification_failed, _rx) = broadcast::channel(100);
         let (tx_block_persisted, _rx) = broadcast::channel(100);
 
         let ctx = AppContext {
@@ -123,6 +129,7 @@ mod tests {
             block_data_cache,
             tx_block_items_received,
             tx_block_verified,
+            tx_block_verification_failed,
             tx_block_persisted,
         };
 
@@ -150,6 +157,7 @@ mod tests {
 
         let (tx_block_items_received, _rx) = mpsc::channel(100);
         let (tx_block_verified, mut rx_block_verified) = mpsc::channel(100);
+        let (tx_block_verification_failed, _rx) = broadcast::channel(100);
         let (tx_block_persisted, _rx) = broadcast::channel(100);
 
         let ctx = AppContext {
@@ -160,6 +168,7 @@ mod tests {
             block_data_cache,
             tx_block_items_received,
             tx_block_verified,
+            tx_block_verification_failed,
             tx_block_persisted,
         };
 

--- a/crates/rock-node-core/src/events.rs
+++ b/crates/rock-node-core/src/events.rs
@@ -23,6 +23,14 @@ pub struct BlockVerified {
     pub cache_key: Uuid,
 }
 
+/// Published by the Verifier plugin when block verification fails.
+#[derive(Debug, Clone)]
+pub struct BlockVerificationFailed {
+    pub block_number: u64,
+    pub cache_key: Uuid,
+    pub reason: String,
+}
+
 /// Published by the Persistence plugin after it has successfully saved the
 /// block to disk.
 #[derive(Debug, Clone, Copy)]

--- a/crates/rock-node-core/src/plugin.rs
+++ b/crates/rock-node-core/src/plugin.rs
@@ -162,6 +162,7 @@ mod tests {
             block_data_cache: Arc::new(crate::cache::BlockDataCache::default()),
             tx_block_items_received: mpsc::channel(100).0,
             tx_block_verified: mpsc::channel(100).0,
+            tx_block_verification_failed: broadcast::channel(100).0,
             tx_block_persisted: broadcast::channel(100).0,
         }
     }

--- a/crates/rock-node-core/src/test_utils.rs
+++ b/crates/rock-node-core/src/test_utils.rs
@@ -29,6 +29,9 @@
 //! and uses `MetricsRegistry::with_registry()` to create a registry with
 //! isolated metric namespaces.
 
+#[cfg(test)]
+use std::sync::Arc;
+
 use crate::metrics::MetricsRegistry;
 
 /// Creates an isolated MetricsRegistry for testing.
@@ -80,7 +83,6 @@ pub fn create_isolated_metrics_with_prefix(_prefix: &str) -> MetricsRegistry {
 }
 
 use crate::events::BlockData;
-use std::sync::Arc;
 
 /// Creates a mock BlockReader for testing.
 ///

--- a/crates/rock-node-observability-plugin/src/lib.rs
+++ b/crates/rock-node-observability-plugin/src/lib.rs
@@ -70,6 +70,7 @@ mod tests {
             block_data_cache: Arc::new(Default::default()),
             tx_block_items_received: tokio::sync::mpsc::channel(100).0,
             tx_block_verified: tokio::sync::mpsc::channel(100).0,
+            tx_block_verification_failed: tokio::sync::broadcast::channel(100).0,
             tx_block_persisted: tokio::sync::broadcast::channel(100).0,
         }
     }
@@ -312,6 +313,7 @@ mod tests {
             block_data_cache: Arc::new(Default::default()),
             tx_block_items_received: tokio::sync::mpsc::channel(100).0,
             tx_block_verified: tokio::sync::mpsc::channel(100).0,
+            tx_block_verification_failed: tokio::sync::broadcast::channel(100).0,
             tx_block_persisted: tokio::sync::broadcast::channel(100).0,
         };
 

--- a/crates/rock-node-persistence-plugin/src/hot_tier.rs
+++ b/crates/rock-node-persistence-plugin/src/hot_tier.rs
@@ -29,7 +29,7 @@ impl HotTier {
             .ok_or_else(|| anyhow!("Could not get handle for CF: {}", CF_HOT_BLOCKS))?;
 
         let key = block_number.to_be_bytes();
-        match self.db.get_cf(cf, &key)? {
+        match self.db.get_cf(cf, key)? {
             Some(db_vec) => {
                 let stored_block: StoredBlock = bincode::deserialize(&db_vec)?;
                 Ok(Some(stored_block.contents))
@@ -111,7 +111,7 @@ impl HotTier {
         };
         let value = bincode::serialize(&stored_block)?;
 
-        batch.put_cf(cf, &key, &value);
+        batch.put_cf(cf, key, &value);
         Ok(())
     }
 
@@ -122,7 +122,7 @@ impl HotTier {
             .ok_or_else(|| anyhow!("Could not get handle for CF: {}", CF_HOT_BLOCKS))?;
 
         let key = block_number.to_be_bytes();
-        batch.delete_cf(cf, &key);
+        batch.delete_cf(cf, key);
         Ok(())
     }
 

--- a/crates/rock-node-persistence-plugin/src/state.rs
+++ b/crates/rock-node-persistence-plugin/src/state.rs
@@ -39,7 +39,7 @@ impl StateManager {
             .db
             .cf_handle(CF_METADATA)
             .ok_or_else(|| anyhow!("Could not get handle for CF: {}", CF_METADATA))?;
-        batch.put_cf(cf, key, &value.to_be_bytes());
+        batch.put_cf(cf, key, value.to_be_bytes());
         Ok(())
     }
 
@@ -48,7 +48,7 @@ impl StateManager {
             .db
             .cf_handle(CF_METADATA)
             .ok_or_else(|| anyhow!("Could not get handle for CF: {}", CF_METADATA))?;
-        self.db.put_cf(cf, key, &value.to_be_bytes())?;
+        self.db.put_cf(cf, key, value.to_be_bytes())?;
         Ok(())
     }
 
@@ -197,7 +197,7 @@ impl StateManager {
             }
         }
 
-        batch.put_cf(cf, &final_start.to_be_bytes(), &final_end.to_be_bytes());
+        batch.put_cf(cf, final_start.to_be_bytes(), final_end.to_be_bytes());
         Ok(())
     }
 
@@ -207,12 +207,12 @@ impl StateManager {
             .cf_handle(CF_GAPS)
             .ok_or_else(|| anyhow!("Could not get handle for CF: {}", CF_GAPS))?;
         if let Some((start, end)) = self.find_containing_gap(block_number)? {
-            batch.delete_cf(cf, &start.to_be_bytes());
+            batch.delete_cf(cf, start.to_be_bytes());
             if block_number > start {
-                batch.put_cf(cf, &start.to_be_bytes(), &(block_number - 1).to_be_bytes());
+                batch.put_cf(cf, start.to_be_bytes(), (block_number - 1).to_be_bytes());
             }
             if block_number < end {
-                batch.put_cf(cf, &(block_number + 1).to_be_bytes(), &end.to_be_bytes());
+                batch.put_cf(cf, (block_number + 1).to_be_bytes(), end.to_be_bytes());
             }
         }
         Ok(())
@@ -223,7 +223,7 @@ impl StateManager {
             .db
             .cf_handle(CF_SKIPPED_BATCHES)
             .ok_or_else(|| anyhow!("Could not get handle for CF: {}", CF_SKIPPED_BATCHES))?;
-        batch.put_cf(cf, &batch_start_block.to_be_bytes(), b"");
+        batch.put_cf(cf, batch_start_block.to_be_bytes(), b"");
         Ok(())
     }
 
@@ -236,7 +236,7 @@ impl StateManager {
             .db
             .cf_handle(CF_SKIPPED_BATCHES)
             .ok_or_else(|| anyhow!("Could not get handle for CF: {}", CF_SKIPPED_BATCHES))?;
-        batch.delete_cf(cf, &batch_start_block.to_be_bytes());
+        batch.delete_cf(cf, batch_start_block.to_be_bytes());
         Ok(())
     }
 
@@ -247,7 +247,7 @@ impl StateManager {
             .ok_or_else(|| anyhow!("Could not get handle for CF: {}", CF_SKIPPED_BATCHES))?;
         Ok(self
             .db
-            .get_cf(cf, &batch_start_block.to_be_bytes())?
+            .get_cf(cf, batch_start_block.to_be_bytes())?
             .is_some())
     }
 }

--- a/crates/rock-node-protobufs/build.rs
+++ b/crates/rock-node-protobufs/build.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
     if !consensus_node_proto_src.exists() {
         println!("cargo:info=Cloning hiero-consensus-node repository...");
         let repo_url = "https://github.com/hiero-ledger/hiero-consensus-node.git";
-        let cn_tag_hash = "c86619410f0e0da3719c39c9447a96438200166d";
+        let cn_tag_hash = "d7cb85ac7384f809a15489635122504661131af4";
         run_command(
             Command::new("git")
                 .arg("clone")

--- a/crates/rock-node-protobufs/src/lib.rs
+++ b/crates/rock-node-protobufs/src/lib.rs
@@ -22,6 +22,9 @@ pub mod com {
                     pub mod output {
                         tonic::include_proto!("com.hedera.hapi.block.stream.output");
                     }
+                    pub mod trace {
+                        tonic::include_proto!("com.hedera.hapi.block.stream.trace");
+                    }
                 }
             }
             pub mod node {
@@ -50,6 +53,12 @@ pub mod com {
                     pub mod tss {
                         tonic::include_proto!("com.hedera.hapi.node.state.tss");
                     }
+                    pub mod hooks {
+                        tonic::include_proto!("com.hedera.hapi.node.state.hooks");
+                    }
+                }
+                pub mod hooks {
+                    tonic::include_proto!("com.hedera.hapi.node.hooks");
                 }
             }
             pub mod platform {

--- a/crates/rock-node-publish-plugin/src/lib.rs
+++ b/crates/rock-node-publish-plugin/src/lib.rs
@@ -167,7 +167,7 @@ impl Plugin for PublishPlugin {
                 )),
             };
             for entry in shared_state.active_sessions.iter() {
-                let _ = entry.value().send(Ok(end_stream_msg.clone())).await;
+                let _ = entry.value().send(Ok(end_stream_msg)).await;
             }
         }
 

--- a/crates/rock-node-publish-plugin/src/service.rs
+++ b/crates/rock-node-publish-plugin/src/service.rs
@@ -90,7 +90,7 @@ impl BlockStreamPublishService for PublishServiceImpl {
                 // Broadcast to all *other* active sessions.
                 for session_entry in shared_state_clone.active_sessions.iter() {
                     if *session_entry.key() != session_id {
-                        let _ = session_entry.value().send(Ok(resend_msg.clone())).await;
+                        let _ = session_entry.value().send(Ok(resend_msg)).await;
                     }
                 }
 

--- a/crates/rock-node-publish-plugin/src/session_manager.rs
+++ b/crates/rock-node-publish-plugin/src/session_manager.rs
@@ -199,6 +199,11 @@ impl SessionManager {
             return BlockAction::EndDuplicate;
         }
 
+        // Note: We DO NOT reject future blocks (block_number > latest_persisted + 1).
+        // The persistence layer handles out-of-order blocks by creating gap ranges,
+        // and the backfill plugin fills those gaps later. This design prioritizes
+        // data availability - we want to accept and persist all blocks we receive.
+
         // Check if this is a duplicate (we're currently streaming this block)
         if let Some(winner_entry) = self.shared_state.block_winners.get(&(block_number as u64)) {
             if *winner_entry == self.id {
@@ -971,6 +976,7 @@ mod tests {
         let metrics = create_test_metrics();
         let (context, _rx_items, _rx_verified, _rx_persisted) = make_context_with_registry(metrics);
         let shared = Arc::new(SharedState::new());
+        shared.set_latest_persisted_block(100); // Set to 100 so block 101 is the expected next
         let (tx1, mut rx1) = mpsc::channel(4);
         let (tx2, mut rx2) = mpsc::channel(4);
         let mut s1 = SessionManager::new(context.clone(), shared.clone(), tx1);
@@ -1062,6 +1068,7 @@ mod tests {
         let (context, mut rx_items, _rx_verified, _rx_persisted) =
             make_context_with_registry(metrics);
         let shared = Arc::new(SharedState::new());
+        shared.set_latest_persisted_block(100); // Set to 100 so block 101 is the expected next
         let (tx, mut rx) = mpsc::channel(8);
         let mut s = SessionManager::new(context.clone(), shared.clone(), tx);
 
@@ -1074,7 +1081,7 @@ mod tests {
                 rock_node_protobufs::com::hedera::hapi::block::stream::output::BlockHeader {
                     hapi_proto_version: None,
                     software_version: None,
-                    number: 200,
+                    number: 101,
                     block_timestamp: None,
                     hash_algorithm: 0,
                 },
@@ -1083,7 +1090,7 @@ mod tests {
         let proof_item = rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem {
             item: Some(BlockItemType::BlockProof(
                 rock_node_protobufs::com::hedera::hapi::block::stream::BlockProof {
-                    block: 200,
+                    block: 101,
                     ..Default::default()
                 },
             )),
@@ -1118,11 +1125,266 @@ mod tests {
             .unwrap();
         match msg.response.unwrap() {
             publish_stream_response::Response::Acknowledgement(ack) => {
-                assert_eq!(ack.block_number, 200)
+                assert_eq!(ack.block_number, 101)
             },
             _ => panic!("Expected Acknowledgement"),
         }
 
-        assert_eq!(shared.get_latest_persisted_block(), 200);
+        assert_eq!(shared.get_latest_persisted_block(), 101);
+    }
+
+    #[tokio::test]
+    async fn verification_failure_sends_bad_block_proof_to_primary() {
+        let metrics = create_test_metrics();
+        let (context, mut rx_items, _rx_verified, _rx_persisted) =
+            make_context_with_registry(metrics);
+        let shared = Arc::new(SharedState::new());
+        shared.set_latest_persisted_block(100); // Set to 100 so block 101 is the expected next
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut s = SessionManager::new(context.clone(), shared.clone(), tx);
+
+        shared.active_sessions.insert(s.id, s.response_tx.clone());
+
+        // Send header + proof for block 101
+        let header_item = rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem {
+            item: Some(BlockItemType::BlockHeader(
+                rock_node_protobufs::com::hedera::hapi::block::stream::output::BlockHeader {
+                    number: 101,
+                    ..Default::default()
+                },
+            )),
+        };
+        let proof_item = rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem {
+            item: Some(BlockItemType::BlockProof(
+                rock_node_protobufs::com::hedera::hapi::block::stream::BlockProof {
+                    block: 101,
+                    ..Default::default()
+                },
+            )),
+        };
+        let req = PublishRequestType::BlockItems(
+            rock_node_protobufs::org::hiero::block::api::BlockItemSet {
+                block_items: vec![header_item, proof_item],
+            },
+        );
+
+        // Simulate verification failure
+        let tx_verification_failed = s.context.tx_block_verification_failed.clone();
+        tokio::spawn(async move {
+            let items_received = rx_items.recv().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = tx_verification_failed.send(rock_node_core::events::BlockVerificationFailed {
+                block_number: items_received.block_number,
+                cache_key: items_received.cache_key,
+                reason: "Invalid block signature".to_string(),
+            });
+        });
+
+        let should_terminate = s.handle_request(req).await;
+        // Verification failure should terminate the session
+        assert!(should_terminate);
+
+        // Expect EndOfStream with BAD_BLOCK_PROOF status
+        let msg = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timeout waiting for response")
+            .unwrap()
+            .unwrap();
+        match msg.response.unwrap() {
+            publish_stream_response::Response::EndStream(eos) => {
+                assert_eq!(
+                    eos.status,
+                    publish_stream_response::end_of_stream::Code::BadBlockProof as i32
+                );
+                assert_eq!(eos.block_number, 101);
+            },
+            _ => panic!("Expected EndStream with BAD_BLOCK_PROOF"),
+        }
+    }
+
+    #[tokio::test]
+    async fn verification_timeout_sends_resend_to_other_sessions() {
+        let metrics = create_test_metrics();
+        let (context, _rx_items, _rx_verified, _rx_persisted) = make_context_with_registry(metrics);
+        let shared = Arc::new(SharedState::new());
+        shared.set_latest_persisted_block(101); // Set to 101 so block 102 is the expected next
+        let (tx1, _rx1) = mpsc::channel(8);
+        let (tx2, mut rx2) = mpsc::channel(8);
+        let mut s1 = SessionManager::new(context.clone(), shared.clone(), tx1);
+        let s2_id = {
+            let s2 = SessionManager::new(context.clone(), shared.clone(), tx2.clone());
+            s2.id
+        };
+
+        // Register both sessions
+        shared.active_sessions.insert(s1.id, s1.response_tx.clone());
+        shared.active_sessions.insert(s2_id, tx2.clone());
+
+        // Send header + proof for block 102
+        let header_item = rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem {
+            item: Some(BlockItemType::BlockHeader(
+                rock_node_protobufs::com::hedera::hapi::block::stream::output::BlockHeader {
+                    number: 102,
+                    ..Default::default()
+                },
+            )),
+        };
+        let proof_item = rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem {
+            item: Some(BlockItemType::BlockProof(
+                rock_node_protobufs::com::hedera::hapi::block::stream::BlockProof {
+                    block: 102,
+                    ..Default::default()
+                },
+            )),
+        };
+        let req = PublishRequestType::BlockItems(
+            rock_node_protobufs::org::hiero::block::api::BlockItemSet {
+                block_items: vec![header_item, proof_item],
+            },
+        );
+
+        // Don't send any verification or persistence events - let it timeout
+        let should_terminate = s1.handle_request(req).await;
+        // Timeout DOES terminate the primary session
+        assert!(should_terminate);
+
+        // Session 2 (non-primary) should receive ResendBlock
+        let msg2 = tokio::time::timeout(Duration::from_secs(2), rx2.recv())
+            .await
+            .expect("timeout waiting for ResendBlock to non-primary")
+            .unwrap()
+            .unwrap();
+        match msg2.response.unwrap() {
+            publish_stream_response::Response::ResendBlock(resend) => {
+                assert_eq!(resend.block_number, 102);
+            },
+            _ => panic!("Expected ResendBlock to non-primary"),
+        }
+    }
+
+    #[tokio::test]
+    async fn header_handles_behind_blocks() {
+        let (context, _rx_items, _rx_verified, _rx_persisted) = make_context();
+        let shared = Arc::new(SharedState::new());
+        shared.set_latest_persisted_block(100);
+        let (tx, mut rx) = mpsc::channel(4);
+        let mut session = SessionManager::new(context, shared, tx);
+
+        // Sending header 50 (< latest_persisted = 100) should be Behind
+        let header_item = rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem {
+            item: Some(BlockItemType::BlockHeader(
+                rock_node_protobufs::com::hedera::hapi::block::stream::output::BlockHeader {
+                    number: 50,
+                    ..Default::default()
+                },
+            )),
+        };
+        let req = PublishRequestType::BlockItems(
+            rock_node_protobufs::org::hiero::block::api::BlockItemSet {
+                block_items: vec![header_item],
+            },
+        );
+
+        // Should terminate with Behind
+        assert!(session.handle_request(req).await);
+        let msg = rx.try_recv().unwrap().unwrap();
+        match msg.response.unwrap() {
+            publish_stream_response::Response::EndStream(eos) => {
+                assert_eq!(
+                    eos.status,
+                    publish_stream_response::end_of_stream::Code::Behind as i32
+                );
+                // EndOfStream contains latest_persisted (100), not the attempted block (50)
+                assert_eq!(eos.block_number, 100);
+            },
+            _ => panic!("Expected EndStream Behind"),
+        }
+    }
+
+    #[tokio::test]
+    async fn verification_failure_sends_resend_to_other_sessions() {
+        let metrics = create_test_metrics();
+        let (context, mut rx_items, _rx_verified, _rx_persisted) =
+            make_context_with_registry(metrics);
+        let shared = Arc::new(SharedState::new());
+        shared.set_latest_persisted_block(102); // Set to 102 so block 103 is the expected next
+        let (tx1, mut rx1) = mpsc::channel(8);
+        let (tx2, mut rx2) = mpsc::channel(8);
+        let mut s1 = SessionManager::new(context.clone(), shared.clone(), tx1);
+        let s2_id = {
+            let s2 = SessionManager::new(context.clone(), shared.clone(), tx2.clone());
+            s2.id
+        };
+
+        // Register both sessions
+        shared.active_sessions.insert(s1.id, s1.response_tx.clone());
+        shared.active_sessions.insert(s2_id, tx2.clone());
+
+        // Send header + proof from primary session
+        let header_item = rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem {
+            item: Some(BlockItemType::BlockHeader(
+                rock_node_protobufs::com::hedera::hapi::block::stream::output::BlockHeader {
+                    number: 103,
+                    ..Default::default()
+                },
+            )),
+        };
+        let proof_item = rock_node_protobufs::com::hedera::hapi::block::stream::BlockItem {
+            item: Some(BlockItemType::BlockProof(
+                rock_node_protobufs::com::hedera::hapi::block::stream::BlockProof {
+                    block: 103,
+                    ..Default::default()
+                },
+            )),
+        };
+        let req = PublishRequestType::BlockItems(
+            rock_node_protobufs::org::hiero::block::api::BlockItemSet {
+                block_items: vec![header_item, proof_item],
+            },
+        );
+
+        // Simulate verification failure
+        let tx_verification_failed = s1.context.tx_block_verification_failed.clone();
+        tokio::spawn(async move {
+            let items_received = rx_items.recv().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = tx_verification_failed.send(rock_node_core::events::BlockVerificationFailed {
+                block_number: items_received.block_number,
+                cache_key: items_received.cache_key,
+                reason: "Invalid proof".to_string(),
+            });
+        });
+
+        let should_terminate = s1.handle_request(req).await;
+        assert!(should_terminate);
+
+        // Primary session should get BAD_BLOCK_PROOF
+        let msg1 = tokio::time::timeout(Duration::from_secs(1), rx1.recv())
+            .await
+            .expect("timeout waiting for BAD_BLOCK_PROOF")
+            .unwrap()
+            .unwrap();
+        match msg1.response.unwrap() {
+            publish_stream_response::Response::EndStream(eos) => {
+                assert_eq!(
+                    eos.status,
+                    publish_stream_response::end_of_stream::Code::BadBlockProof as i32
+                );
+            },
+            _ => panic!("Expected BAD_BLOCK_PROOF to primary"),
+        }
+
+        // Other session should get ResendBlock
+        let msg2 = tokio::time::timeout(Duration::from_secs(1), rx2.recv())
+            .await
+            .expect("timeout waiting for ResendBlock")
+            .unwrap()
+            .unwrap();
+        match msg2.response.unwrap() {
+            publish_stream_response::Response::ResendBlock(resend) => {
+                assert_eq!(resend.block_number, 103);
+            },
+            _ => panic!("Expected ResendBlock to other session"),
+        }
     }
 }

--- a/crates/rock-node-publish-plugin/src/state.rs
+++ b/crates/rock-node-publish-plugin/src/state.rs
@@ -16,6 +16,25 @@ pub enum SessionState {
     Behind,
 }
 
+/// Action to take for a block request (matches Java's BlockAction)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockAction {
+    /// Accept block items, add to buffer
+    Accept,
+    /// Send SkipBlock response
+    Skip,
+    /// Send ResendBlock response
+    Resend,
+    /// Send EndOfStream(BEHIND)
+    EndBehind,
+    /// Send EndOfStream(DUPLICATE_BLOCK)
+    EndDuplicate,
+    /// Send EndOfStream(ERROR)
+    EndError,
+    /// Send EndOfStream(BAD_BLOCK_PROOF)
+    BadBlockProof,
+}
+
 /// The central, shared state for the entire Publish Plugin.
 #[derive(Debug)]
 pub struct SharedState {
@@ -25,6 +44,12 @@ pub struct SharedState {
     pub latest_persisted_block: AtomicI64,
     /// Maps a session ID to its response channel sender to broadcast messages.
     pub active_sessions: DashMap<Uuid, mpsc::Sender<Result<PublishStreamResponse, Status>>>,
+}
+
+impl Default for SharedState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SharedState {

--- a/crates/rock-node-query-plugin/src/handlers/consensus_handler.rs
+++ b/crates/rock-node-query-plugin/src/handlers/consensus_handler.rs
@@ -47,7 +47,7 @@ impl ConsensusQueryHandler {
         let state_id = StateIdentifier::StateIdTopics as u32;
 
         let map_key = MapChangeKey {
-            key_choice: Some(map_change_key::KeyChoice::TopicIdKey(topic_id.clone())),
+            key_choice: Some(map_change_key::KeyChoice::TopicIdKey(topic_id)),
         };
 
         let db_key = [state_id.to_be_bytes().as_slice(), &map_key.encode_to_vec()].concat();

--- a/crates/rock-node-query-plugin/src/handlers/crypto_handler.rs
+++ b/crates/rock-node-query-plugin/src/handlers/crypto_handler.rs
@@ -89,14 +89,12 @@ impl CryptoQueryHandler {
                         contract_account_id: if account.smart_contract {
                             if !account.alias.is_empty() {
                                 hex::encode(account.alias.clone())
+                            } else if let Some(AccountIdType::AccountNum(num)) =
+                                account.account_id.as_ref().unwrap().account
+                            {
+                                format!("0.0.{}", num)
                             } else {
-                                if let Some(AccountIdType::AccountNum(num)) =
-                                    account.account_id.as_ref().unwrap().account
-                                {
-                                    format!("0.0.{}", num)
-                                } else {
-                                    String::new()
-                                }
+                                String::new()
                             }
                         } else {
                             String::new()

--- a/crates/rock-node-query-plugin/src/handlers/file_handler.rs
+++ b/crates/rock-node-query-plugin/src/handlers/file_handler.rs
@@ -39,7 +39,7 @@ impl FileQueryHandler {
 
         let state_id = StateIdentifier::StateIdFiles as u32;
         let map_key = MapChangeKey {
-            key_choice: Some(map_change_key::KeyChoice::FileIdKey(file_id.clone())),
+            key_choice: Some(map_change_key::KeyChoice::FileIdKey(file_id)),
         };
         let db_key = [state_id.to_be_bytes().as_slice(), &map_key.encode_to_vec()].concat();
 
@@ -59,7 +59,7 @@ impl FileQueryHandler {
                     map_change_value.value_choice
                 {
                     let file_info = file_get_info_response::FileInfo {
-                        file_id: Some(file_id.clone()),
+                        file_id: Some(file_id),
                         size: file.contents.len() as i64,
                         expiration_time: if file.expiration_second > 0 {
                             Some(Timestamp {
@@ -108,7 +108,7 @@ impl FileQueryHandler {
 
         let state_id = StateIdentifier::StateIdFiles as u32;
         let map_key = MapChangeKey {
-            key_choice: Some(map_change_key::KeyChoice::FileIdKey(file_id.clone())),
+            key_choice: Some(map_change_key::KeyChoice::FileIdKey(file_id)),
         };
         let db_key = [state_id.to_be_bytes().as_slice(), &map_key.encode_to_vec()].concat();
 
@@ -128,7 +128,7 @@ impl FileQueryHandler {
                     map_change_value.value_choice
                 {
                     let file_contents = file_get_contents_response::FileContents {
-                        file_id: Some(file_id.clone()),
+                        file_id: Some(file_id),
                         contents: file.contents,
                     };
                     FileGetContentsResponse {

--- a/crates/rock-node-query-plugin/src/handlers/network_handler.rs
+++ b/crates/rock-node-query-plugin/src/handlers/network_handler.rs
@@ -191,7 +191,7 @@ impl NetworkQueryHandler {
         account: &rock_node_protobufs::proto::Account,
     ) -> Result<Vec<TokenRelationship>, Status> {
         let mut relationships = Vec::new();
-        let mut current_token_id = account.head_token_id.clone();
+        let mut current_token_id = account.head_token_id;
 
         let state_id = StateIdentifier::StateIdTokenRelations as u32;
 
@@ -203,7 +203,7 @@ impl NetworkQueryHandler {
             let map_key = MapChangeKey {
                 key_choice: Some(map_change_key::KeyChoice::TokenRelationshipKey(
                     rock_node_protobufs::proto::TokenAssociation {
-                        token_id: current_token_id.clone(),
+                        token_id: current_token_id,
                         account_id: account.account_id.clone(),
                     },
                 )),

--- a/crates/rock-node-query-plugin/src/handlers/schedule_handler.rs
+++ b/crates/rock-node-query-plugin/src/handlers/schedule_handler.rs
@@ -44,9 +44,7 @@ impl ScheduleQueryHandler {
         let state_id = StateIdentifier::StateIdSchedulesById as u32;
 
         let map_key = MapChangeKey {
-            key_choice: Some(map_change_key::KeyChoice::ScheduleIdKey(
-                schedule_id.clone(),
-            )),
+            key_choice: Some(map_change_key::KeyChoice::ScheduleIdKey(schedule_id)),
         };
 
         let db_key = [state_id.to_be_bytes().as_slice(), &map_key.encode_to_vec()].concat();
@@ -66,7 +64,7 @@ impl ScheduleQueryHandler {
                     map_change_value.value_choice
                 {
                     let schedule_info = ScheduleInfo {
-                        schedule_id: Some(schedule_id.clone()),
+                        schedule_id: Some(schedule_id),
                         memo: schedule.memo,
                         admin_key: schedule.admin_key,
                         payer_account_id: schedule.payer_account_id,

--- a/crates/rock-node-query-plugin/src/handlers/token_handler.rs
+++ b/crates/rock-node-query-plugin/src/handlers/token_handler.rs
@@ -38,7 +38,7 @@ impl TokenQueryHandler {
 
         let state_id = StateIdentifier::StateIdTokens as u32;
         let map_key = MapChangeKey {
-            key_choice: Some(map_change_key::KeyChoice::TokenIdKey(token_id.clone())),
+            key_choice: Some(map_change_key::KeyChoice::TokenIdKey(token_id)),
         };
         let db_key = [state_id.to_be_bytes().as_slice(), &map_key.encode_to_vec()].concat();
 
@@ -134,7 +134,7 @@ impl TokenQueryHandler {
 
         let state_id = StateIdentifier::StateIdNfts as u32;
         let map_key = MapChangeKey {
-            key_choice: Some(map_change_key::KeyChoice::NftIdKey(nft_id.clone())),
+            key_choice: Some(map_change_key::KeyChoice::NftIdKey(nft_id)),
         };
         let db_key = [state_id.to_be_bytes().as_slice(), &map_key.encode_to_vec()].concat();
 

--- a/crates/rock-node-query-plugin/src/services/contract_service.rs
+++ b/crates/rock-node-query-plugin/src/services/contract_service.rs
@@ -145,4 +145,13 @@ impl SmartContractService for SmartContractServiceImpl {
             cost: 0,
         }))
     }
+    async fn lambda_s_store(
+        &self,
+        _request: Request<Transaction>,
+    ) -> Result<Response<TransactionResponse>, Status> {
+        Ok(Response::new(TransactionResponse {
+            node_transaction_precheck_code: ResponseCodeEnum::NotSupported as i32,
+            cost: 0,
+        }))
+    }
 }

--- a/crates/rock-node-server-status-plugin/src/lib.rs
+++ b/crates/rock-node-server-status-plugin/src/lib.rs
@@ -172,6 +172,7 @@ mod tests {
             block_data_cache: Arc::new(Default::default()),
             tx_block_items_received: tokio::sync::mpsc::channel(100).0,
             tx_block_verified: tokio::sync::mpsc::channel(100).0,
+            tx_block_verification_failed: tokio::sync::broadcast::channel(100).0,
             tx_block_persisted: tokio::sync::broadcast::channel(100).0,
         }
     }

--- a/crates/rock-node-state-management-plugin/src/plugin.rs
+++ b/crates/rock-node-state-management-plugin/src/plugin.rs
@@ -26,6 +26,12 @@ pub struct StateManagementPlugin {
     shutdown_notify: Arc<Notify>,
 }
 
+impl Default for StateManagementPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StateManagementPlugin {
     pub fn new() -> Self {
         Self {

--- a/crates/rock-node-subscriber-plugin/src/session.rs
+++ b/crates/rock-node-subscriber-plugin/src/session.rs
@@ -421,6 +421,7 @@ mod tests {
                 block_data_cache: Arc::new(Default::default()),
                 tx_block_items_received: tokio::sync::mpsc::channel(1).0,
                 tx_block_verified: tokio::sync::mpsc::channel(1).0,
+                tx_block_verification_failed: tokio::sync::broadcast::channel(1).0,
                 tx_block_persisted: tx_persisted.clone(),
             }),
             tx_persisted,

--- a/crates/rock-node-verifier-plugin/Cargo.toml
+++ b/crates/rock-node-verifier-plugin/Cargo.toml
@@ -5,10 +5,12 @@ edition = "2021"
 
 [dependencies]
 rock-node-core = { path = "../rock-node-core" }
+rock-node-protobufs = { path = "../rock-node-protobufs" }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 tracing = "0.1"
 uuid = "1"
+prost = "0.13"
 
 # Add async-trait for async methods in traits
 async-trait = "0.1"

--- a/docs/publisher/design-doc.md
+++ b/docs/publisher/design-doc.md
@@ -216,9 +216,10 @@ The core of the plugin is the "primary election" and subsequent state transition
 2. It reads `SharedState::latest_persisted_block` to perform initial validation.
 3. If N < latest_persisted, it is behind. The server sends `EndOfStream(Behind)` and closes the connection.
 4. If N == latest_persisted, it is a duplicate (already persisted). The server sends `EndOfStream(DuplicateBlock)` and closes the connection.
-5. If N > latest_persisted + 1, it is a future block (gap). The server sends `EndOfStream(Behind)` and closes the connection.
-6. If N == latest_persisted + 1 (the expected block), the session attempts to "win" the election by inserting its unique session ID into `SharedState::block_winners` for key N.
-7. The `DashMap::entry().or_insert()` operation atomically guarantees that only one session can be the first to write its ID.
+5. If N > latest_persisted (including future blocks that create gaps), the session attempts to "win" the election by inserting its unique session ID into `SharedState::block_winners` for key N.
+6. The `DashMap::entry().or_insert()` operation atomically guarantees that only one session can be the first to write its ID.
+
+**Note on Future Blocks:** The publish plugin does NOT reject blocks that arrive out of order (N > latest_persisted + 1). This design prioritizes data availability - the persistence layer handles out-of-order blocks by creating gap ranges, and the backfill plugin fills those gaps later.
 
 **Case A (Win):** The session's ID was successfully inserted. It transitions its internal state to `Primary`. It can now buffer `BlockItems`.
 
@@ -290,8 +291,8 @@ The service is defined by a single bidirectional gRPC stream.
   - The client should resend all items for that block.
 - **SkipBlock:** Sent to a non-primary publisher to tell it another publisher won the race and it should not send data for the current block.
 - **EndOfStream:** Sent by the server when it is terminating the connection due to an unrecoverable error. Status codes include:
-  - **DUPLICATE_BLOCK:** Block number ≤ latest persisted block
-  - **BEHIND:** Block number > latest persisted block + 1 (future block)
+  - **DUPLICATE_BLOCK:** Block number == latest persisted block (already stored)
+  - **BEHIND:** Block number < latest persisted block (old block we already have)
   - **BAD_BLOCK_PROOF:** Block failed verification (invalid structure, signatures, or proof)
   - **END_STREAM_ERROR:** Generic error or client-initiated graceful close
 
@@ -328,7 +329,7 @@ A Counter tracking the number of successfully persisted blocks via this plugin.
 ### 7.2 Logging
 
 - **INFO:** New connections, session state transitions (becoming primary), successful block publications, and connection terminations are logged with the unique `session_id`.
-- **WARN:** Duplicate/future blocks, persistence timeouts, and failures to send messages to a client (likely due to a disconnected client) are logged.
+- **WARN:** Duplicate/behind blocks, verification failures, persistence timeouts, and failures to send messages to a client (likely due to a disconnected client) are logged.
 - **ERROR:** Critical failures like the gRPC server failing to start or failure to send an event on a core channel.
 
 ---

--- a/proto/block-node/api/shared_message_types.proto
+++ b/proto/block-node/api/shared_message_types.proto
@@ -31,3 +31,14 @@ message BlockItemSet {
      */
     repeated com.hedera.hapi.block.stream.BlockItem block_items = 1;
 }
+
+message BlockEnd {
+    /**
+     * A Block Number.<br/>
+     * This is the block number of the completed block.
+     * <p>
+     * This MUST match the block number of corresponding `BlockHeader` block
+     * item that started this block.
+     */
+    uint64 block_number = 1;
+}

--- a/proto/block_stream_publish_service.proto
+++ b/proto/block_stream_publish_service.proto
@@ -50,6 +50,11 @@ message PublishStreamRequest {
          * when sending this message for any non-error condition.
          */
         EndStream end_stream = 2;
+
+        /**
+         * A message indicating the end of a block.
+         */
+        BlockEnd end_of_block = 3;
     }
 
     /**
@@ -230,15 +235,6 @@ message PublishStreamResponse {
          * one greater than this value.
          */
         uint64 block_number = 1;
-
-        /**
-         * A hash of the virtual merkle root for the block.
-         * <p>
-         * This SHALL be the hash calculated by the Block-Node for the
-         * root node of the virtual merkle tree that is signed by the source
-         * system to validate the block.
-         */
-        bytes block_root_hash = 2;
     }
 
     /**

--- a/proto/block_stream_subscribe_service.proto
+++ b/proto/block_stream_subscribe_service.proto
@@ -156,6 +156,16 @@ message SubscribeStreamResponse {
          * followed by a single `status` message.
          */
         BlockItemSet block_items = 2;
+
+        /**
+         * A message indicating the end of a block.
+         * <p>
+         * This message SHALL be sent exactly once for each block.
+         * The next message after a `BlockEnd` SHALL be either a
+         * status message to indicate the stream is closed, or a
+         * `BlockItemSet` message starting with a `BlockHeader`.
+         */
+        BlockEnd end_of_block = 3;
     }
 }
 

--- a/tests/e2e/src/common/block_builder.rs
+++ b/tests/e2e/src/common/block_builder.rs
@@ -80,6 +80,7 @@ impl BlockBuilder {
             change_operation: Some(ChangeOperation::MapUpdate(MapUpdateChange {
                 key: Some(map_key),
                 value: Some(map_value),
+                identical: false,
             })),
         };
 
@@ -125,6 +126,7 @@ impl BlockBuilder {
             change_operation: Some(ChangeOperation::MapUpdate(MapUpdateChange {
                 key: Some(map_key),
                 value: Some(map_value),
+                identical: false,
             })),
         };
 
@@ -167,6 +169,7 @@ impl BlockBuilder {
             change_operation: Some(ChangeOperation::MapUpdate(MapUpdateChange {
                 key: Some(map_key),
                 value: Some(map_value),
+                identical: false,
             })),
         };
 
@@ -211,6 +214,7 @@ impl BlockBuilder {
             change_operation: Some(ChangeOperation::MapUpdate(MapUpdateChange {
                 key: Some(map_key),
                 value: Some(map_value),
+                identical: false,
             })),
         };
 
@@ -256,6 +260,7 @@ impl BlockBuilder {
             change_operation: Some(ChangeOperation::MapUpdate(MapUpdateChange {
                 key: Some(map_key),
                 value: Some(map_value),
+                identical: false,
             })),
         };
 
@@ -300,6 +305,7 @@ impl BlockBuilder {
             change_operation: Some(ChangeOperation::MapUpdate(MapUpdateChange {
                 key: Some(map_key),
                 value: Some(map_value),
+                identical: false,
             })),
         };
 
@@ -345,6 +351,7 @@ impl BlockBuilder {
             change_operation: Some(ChangeOperation::MapUpdate(MapUpdateChange {
                 key: Some(map_key),
                 value: Some(map_value),
+                identical: false,
             })),
         };
 
@@ -403,6 +410,7 @@ impl BlockBuilder {
             change_operation: Some(ChangeOperation::MapUpdate(MapUpdateChange {
                 key: Some(map_key),
                 value: Some(map_value),
+                identical: false,
             })),
         };
 

--- a/tests/integration/src/fixtures/mock_plugins.rs
+++ b/tests/integration/src/fixtures/mock_plugins.rs
@@ -114,6 +114,7 @@ mod tests {
             block_data_cache: Arc::new(rock_node_core::BlockDataCache::new()),
             tx_block_items_received: mpsc::channel(10).0,
             tx_block_verified: mpsc::channel(10).0,
+            tx_block_verification_failed: broadcast::channel(10).0,
             tx_block_persisted: broadcast::channel(10).0,
         }
     }

--- a/tests/integration/src/fixtures/test_context.rs
+++ b/tests/integration/src/fixtures/test_context.rs
@@ -122,6 +122,8 @@ impl IntegrationTestContextBuilder {
         let (tx_block_items_received, rx_block_items_received) =
             mpsc::channel(self.channel_buffer_size);
         let (tx_block_verified, rx_block_verified) = mpsc::channel(self.channel_buffer_size);
+        let (tx_block_verification_failed, _rx_block_verification_failed) =
+            broadcast::channel(self.channel_buffer_size);
         let (tx_block_persisted, _rx_block_persisted) =
             broadcast::channel(self.channel_buffer_size);
 
@@ -134,6 +136,7 @@ impl IntegrationTestContextBuilder {
             block_data_cache: Arc::new(block_data_cache),
             tx_block_items_received,
             tx_block_verified,
+            tx_block_verification_failed,
             tx_block_persisted,
         };
 


### PR DESCRIPTION
### Description

This PR implements a Publish → Verify → Persist architectural flow for block processing, ensuring invalid blocks never reach the persistence layer. The change integrates the Verifier Plugin into the publish workflow, matching the Java implementation's graceful degradation
  approach where publishers sending invalid blocks are terminated while allowing others to retry.

  Key improvements:
  - Blocks are verified BEFORE persistence, preventing database corruption with invalid data
  - Publishers sending invalid blocks receive BAD_BLOCK_PROOF and are terminated immediately
  - Non-primary publishers can retry when verification fails, ensuring system resilience
  - Fixed critical duplicate block detection bug that incorrectly classified block 0 as "Behind" 
### Related Issues

Closes #121 

### Changes
Core Event System:
  - rock-node-core/src/events.rs: Added BlockVerificationFailed event with block number, cache key, and failure reason
  - rock-node-core/src/app_context.rs: Added tx_block_verification_failed broadcast channel to AppContext

  Publish Plugin (Major Refactoring):
  - rock-node-publish-plugin/src/session_manager.rs:
    - Refactored complete_block() to send blocks to Verifier first instead of Persistence
    - Added wait_for_verification_and_persistence() method using tokio::select! to await EITHER verification failure OR persistence success
    - Removed unacknowledged_blocks tracking (no longer needed with verify-first approach)
    - Fixed duplicate block detection logic: changed from block_number <= latest_persisted to block_number < latest_persisted for Behind status
    - Added explicit block_number == latest_persisted check for DuplicateBlock status
    - Sends BAD_BLOCK_PROOF to failing publishers, ResendBlock to others on verification failure

  Verifier Plugin:
  - rock-node-verifier-plugin/src/lib.rs:
    - Added BlockVerificationFailed event emission on validation failure
    - On verification failure: sends event to publishers + marks cache for removal
    - On verification success: sends BlockVerified to Persistence Plugin
  - rock-node-verifier-plugin/Cargo.toml: Added prost and rock-node-protobufs dependencies

  Main Application:
  - app/rock-node/src/main.rs: Added tx_block_verification_failed channel initialization and AppContext integration

  Test Fixes (AppContext Updates):
  - tests/integration/src/fixtures/test_context.rs: Added tx_block_verification_failed to integration test context
  - tests/integration/src/fixtures/mock_plugins.rs: Added verification failed channel
  - tests/e2e/src/common/block_builder.rs: Fixed all MapUpdateChange initializations with missing identical: false field
  - crates/rock-node-block-access-plugin/src/lib.rs: Updated test AppContext
  - crates/rock-node-observability-plugin/src/lib.rs: Updated test AppContext (3 instances)
  - crates/rock-node-server-status-plugin/src/lib.rs: Updated test AppContext
  - crates/rock-node-backfill-plugin/src/lib.rs: Updated test AppContext
  - crates/rock-node-backfill-plugin/src/worker.rs: Updated test AppContext + re-added missing imports
  - crates/rock-node-backfill-plugin/examples/backfill_continious_mode.rs: Updated example AppContext
  - crates/rock-node-core/src/plugin.rs: Updated test helper AppContext
  - crates/rock-node-core/src/test_utils.rs: Added #[cfg(test)] scoped Arc import
  - crates/rock-node-subscriber-plugin/src/session.rs: Updated test AppContext

  Code Cleanup:
  - crates/rock-node-query-plugin/src/services/contract_service.rs: Added missing lambda_s_store trait method implementation
  - Multiple files: Removed dead code (response_from_code() function) and unused imports via cargo clippy --fix

  Documentation:
  - docs/publisher/design-doc.md:
    - Updated architecture diagrams to show Publish → Verify → Persist flow
    - Documented verification failure handling in Primary Publisher Flow (Section 4.2)
    - Added BAD_BLOCK_PROOF status to API documentation
    - Fixed duplicate detection logic documentation
    - Added Section 8.4: Verification-First Architecture explaining design rationale
    - Updated component responsibilities to include verification integration

### Reviewer Checklist

- [ ] The code follows the project's coding standards.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added necessary documentation (if applicable).
- [ ] I have confirmed that this change does not introduce any new security vulnerabilities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Verification-first pipeline: blocks are verified before persistence, with failure events influencing session behavior.
  - Enhanced publisher flow with per-block actions (Accept, Skip, Resend, End* cases) and cross-session coordination.
  - Protocol updates: end-of-block signaling added to publish/subscribe streams; SkipBlock supported; BlockAcknowledgement no longer includes root hash.
  - New API surfaces in protobufs and query service endpoint added (returns NotSupported).
- Documentation
  - Design doc updated to detail the Verify-first architecture, messaging, and session lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->