### PR TITLE
feat: add helm charts

### DIFF
--- a/charts/rock-node/Chart.yaml
+++ b/charts/rock-node/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: rock-node
+description: Helm chart for deploying Rock Node data availability service
+type: application
+version: 0.1.0
+appVersion: "latest"
+
+# Optional dependencies can be declared here if needed in the future
+dependencies: []

--- a/charts/rock-node/README.md
+++ b/charts/rock-node/README.md
@@ -1,0 +1,70 @@
+# Rock Node Helm Chart
+
+This chart deploys the Rock Node service together with the configuration,
+persistent storage, and observability endpoints required to run the data
+availability node inside Kubernetes.
+
+## Installing
+
+```bash
+helm install rock-node charts/rock-node \
+  --namespace rock-node \
+  --create-namespace
+```
+
+Override image repository, tag, and any environment specific configuration as
+needed:
+
+```bash
+helm upgrade --install rock-node charts/rock-node \
+  --namespace rock-node \
+  --set image.repository=ghcr.io/limechain/rock-node \
+  --set image.tag=latest
+```
+
+To expose the service on fixed TCP ports reachable from other machines on your
+LAN, switch the Service to `NodePort` and assign port numbers:
+```bash
+helm upgrade --install rock-node charts/rock-node \
+  --namespace rock-node \
+  --set service.type=NodePort \
+  --set service.grpc.nodePort=23513 \
+  --set service.metrics.nodePort=23514
+```
+
+This exposes:
+
+- `http://<k3s-node-ip>:23513` (TCP) → Rock Node gRPC endpoint
+- `http://<k3s-node-ip>:23514` → Observability `/metrics`, `/readyz`, `/livez`
+
+## Argo CD Application
+
+To have Argo CD reconcile this chart automatically, point the Application
+manifest at the chart directory and enable automated sync:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rock-node
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:LimeChain/Rock-Node.git
+    targetRevision: main
+    path: charts/rock-node
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: rock-node
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+```
+
+When releasing, publish a container image for Rock Node and bump the chart’s
+`appVersion`/`image.tag`. Pushing that change to the Git repository Argo CD
+watches will trigger a sync and roll out the new version automatically.

--- a/charts/rock-node/templates/_helpers.tpl
+++ b/charts/rock-node/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{- define "rock-node.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "rock-node.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "rock-node.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "rock-node.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "rock-node.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "rock-node.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rock-node/templates/configmap.yaml.tpl
+++ b/charts/rock-node/templates/configmap.yaml.tpl
@@ -1,0 +1,15 @@
+{{- if not .Values.config.existingConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rock-node.fullname" . }}-config
+  namespace: {{ include "rock-node.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rock-node.name" . }}
+    helm.sh/chart: {{ include "rock-node.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  {{ .Values.config.fileName }}: |
+{{- $.Values.config.content | indent 4 }}
+{{- end }}

--- a/charts/rock-node/templates/deployment.yaml.tpl
+++ b/charts/rock-node/templates/deployment.yaml.tpl
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rock-node.fullname" . }}
+  namespace: {{ include "rock-node.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rock-node.name" . }}
+    helm.sh/chart: {{ include "rock-node.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rock-node.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "rock-node.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.podLabels }}
+{{ toYaml . | indent 6 }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "rock-node.serviceAccountName" . }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- if and .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        {{- if .Values.securityContext.supplementalGroups }}
+        supplementalGroups:
+{{ toYaml .Values.securityContext.supplementalGroups | indent 10 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: rock-node
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if and .Values.containerSecurityContext.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+            capabilities:
+{{ toYaml .Values.containerSecurityContext.capabilities | indent 14 }}
+          {{- end }}
+          env:
+            {{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 12 }}
+            {{- else }}
+            []
+            {{- end }}
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.service.grpc.targetPort }}
+              protocol: TCP
+            {{- if .Values.service.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.service.metrics.targetPort }}
+              protocol: TCP
+            {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: {{ .Values.probes.liveness.port }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: {{ .Values.probes.readiness.port }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /app/data
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          {{- if .Values.config.existingConfigMap }}
+          configMap:
+            name: {{ .Values.config.existingConfigMap }}
+          {{- else }}
+          configMap:
+            name: {{ include "rock-node.fullname" . }}-config
+          {{- end }}
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{ else }}{{ include "rock-node.fullname" . }}-data{{ end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/charts/rock-node/templates/ingress.yaml.tpl
+++ b/charts/rock-node/templates/ingress.yaml.tpl
@@ -1,0 +1,51 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "rock-node.fullname" . }}
+  namespace: {{ include "rock-node.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rock-node.name" . }}
+    helm.sh/chart: {{ include "rock-node.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - {{- if .host }}
+      host: {{ .host }}
+      {{- end }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                {{- if eq .backend "grpc" }}
+                name: {{ include "rock-node.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.grpc.port }}
+                {{- else if eq .backend "metrics" }}
+                name: {{ include "rock-node.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.metrics.port }}
+                {{- else }}
+                name: {{ .backend }}
+                port:
+                  number: {{ $.Values.service.grpc.port }}
+                {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/rock-node/templates/pvc.yaml.tpl
+++ b/charts/rock-node/templates/pvc.yaml.tpl
@@ -1,0 +1,29 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rock-node.fullname" . }}-data
+  namespace: {{ include "rock-node.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rock-node.name" . }}
+    helm.sh/chart: {{ include "rock-node.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+{{ toYaml .Values.persistence.accessModes | indent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+  {{- with .Values.persistence.selector }}
+  selector:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/rock-node/templates/service.yaml.tpl
+++ b/charts/rock-node/templates/service.yaml.tpl
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rock-node.fullname" . }}
+  namespace: {{ include "rock-node.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rock-node.name" . }}
+    helm.sh/chart: {{ include "rock-node.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "rock-node.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: grpc
+      port: {{ .Values.service.grpc.port }}
+      targetPort: {{ .Values.service.grpc.targetPort }}
+      protocol: TCP
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.grpc.nodePort }}
+      nodePort: {{ .Values.service.grpc.nodePort }}
+      {{- end }}
+    {{- if .Values.service.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.service.metrics.port }}
+      targetPort: {{ .Values.service.metrics.targetPort }}
+      protocol: TCP
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.metrics.nodePort }}
+      nodePort: {{ .Values.service.metrics.nodePort }}
+      {{- end }}
+    {{- end }}

--- a/charts/rock-node/templates/serviceaccount.yaml.tpl
+++ b/charts/rock-node/templates/serviceaccount.yaml.tpl
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rock-node.serviceAccountName" . }}
+  namespace: {{ include "rock-node.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rock-node.name" . }}
+    helm.sh/chart: {{ include "rock-node.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/rock-node/templates/servicemonitor.yaml.tpl
+++ b/charts/rock-node/templates/servicemonitor.yaml.tpl
@@ -1,0 +1,29 @@
+{{- if and .Values.serviceMonitor.enabled .Values.service.metrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "rock-node.fullname" . }}
+  namespace: {{ include "rock-node.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rock-node.name" . }}
+    helm.sh/chart: {{ include "rock-node.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.serviceMonitor.labels }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- with .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rock-node.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/rock-node/values.yaml
+++ b/charts/rock-node/values.yaml
@@ -1,0 +1,174 @@
+# Default values for rock-node Helm chart.
+# This file documents the main configuration knobs used by the templates.
+
+namespaceOverride: ""
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+image:
+  repository: ghcr.io/limechain/rock-node
+  tag: latest
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 768Mi
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+securityContext:
+  enabled: true
+  fsGroup: 2000
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  supplementalGroups: []
+
+containerSecurityContext:
+  enabled: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+config:
+  existingConfigMap: ""
+  fileName: config.toml
+  content: |
+    # =========================================
+    # Core Application Configuration
+    # =========================================
+    [core]
+    log_level = "INFO"
+    database_path = "data/database"
+    start_block_number = 0
+    grpc_address = "0.0.0.0"
+    grpc_port = 8090
+
+    # =========================================
+    # Plugin-Specific Configurations
+    # =========================================
+    [plugins]
+
+        [plugins.observability]
+        enabled = true
+        listen_address = "0.0.0.0:9600"
+
+        [plugins.publish_service]
+        enabled = true
+        max_concurrent_streams = 250
+        persistence_ack_timeout_seconds = 60
+        stale_winner_timeout_seconds = 10
+        winner_cleanup_interval_seconds = 150
+        winner_cleanup_threshold_blocks = 1000
+
+        [plugins.persistence_service]
+        enabled = true
+        cold_storage_path = "data/cold_storage"
+        hot_storage_block_count = 100
+        archive_batch_size = 100
+
+        [plugins.state_management_service]
+        enabled = false
+
+        [plugins.subscriber_service]
+        enabled = true
+        max_concurrent_streams = 100
+        live_stream_queue_size = 250
+        max_future_block_lookahead = 250
+        session_timeout_seconds = 60
+
+        [plugins.verification_service]
+        enabled = true
+
+        [plugins.block_access_service]
+        enabled = true
+
+        [plugins.server_status_service]
+        enabled = true
+
+        [plugins.query_service]
+        enabled = false
+
+        [plugins.backfill]
+        enabled = false
+        mode = "GapFill"
+        peers = ["http://127.0.0.1:8090"]
+        check_interval_seconds = 5
+        max_batch_size = 10
+
+service:
+  type: ClusterIP
+  annotations: {}
+  grpc:
+    port: 8090
+    targetPort: 8090
+    nodePort: null
+  metrics:
+    enabled: true
+    port: 9600
+    targetPort: 9600
+    nodePort: null
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+probes:
+  readiness:
+    enabled: true
+    path: /readyz
+    port: 9600
+    initialDelaySeconds: 10
+    periodSeconds: 15
+  liveness:
+    enabled: true
+    path: /livez
+    port: 9600
+    initialDelaySeconds: 30
+    periodSeconds: 30
+
+persistence:
+  enabled: true
+  accessModes:
+    - ReadWriteOnce
+  size: 100Gi
+  storageClassName: ""
+  existingClaim: ""
+  annotations: {}
+  selector: {}
+
+extraVolumeMounts: []
+extraVolumes: []
+
+extraEnv: []
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+  annotations: {}
+
+# Optional topology spread constraints or pod disruption budget can be added later.

--- a/crates/rock-node-observability-plugin/src/lib.rs
+++ b/crates/rock-node-observability-plugin/src/lib.rs
@@ -24,6 +24,7 @@ mod tests {
     use super::*;
     use rock_node_core::{
         app_context::AppContext,
+        capability::Capability,
         config::{
             BackfillConfig, BlockAccessServiceConfig, Config, CoreConfig, PluginConfigs,
             ServerStatusServiceConfig,
@@ -340,6 +341,25 @@ mod tests {
         plugin.stop().await.unwrap();
         assert!(!plugin.is_running());
     }
+
+    #[tokio::test]
+    async fn test_readiness_depends_on_block_reader_capability() {
+        use axum::extract::State;
+
+        let ctx = create_test_context(true);
+
+        let (status, body) = readiness_check(State(ctx.clone())).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body, "NOT_READY");
+
+        ctx.capability_registry
+            .register(Capability::ProvidesBlockReader)
+            .await;
+
+        let (status, body) = readiness_check(State(ctx.clone())).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "READY");
+    }
 }
 
 #[derive(Debug, Default)]
@@ -380,7 +400,7 @@ async fn health_check() -> impl IntoResponse {
 
 /// Readiness probe - checks if the service is ready to accept traffic.
 /// Verifies that critical capabilities are registered before serving traffic.
-async fn readiness_check(State(ctx): State<AppContext>) -> impl IntoResponse {
+async fn readiness_check(State(ctx): State<AppContext>) -> (StatusCode, &'static str) {
     use rock_node_core::capability::Capability;
 
     // Check if critical capabilities are registered

--- a/crates/rock-node-persistence-plugin/src/lib.rs
+++ b/crates/rock-node-persistence-plugin/src/lib.rs
@@ -207,6 +207,15 @@ impl Plugin for PersistencePlugin {
             );
             debug!("PersistencePlugin registered providers for BlockReader and BlockWriter.");
         }
+
+        // Announce that the application can serve block reads.
+        let capability_registry = context.capability_registry.clone();
+        tokio::spawn(async move {
+            capability_registry
+                .register(Capability::ProvidesBlockReader)
+                .await;
+        });
+
         Ok(())
     }
 

--- a/crates/rock-node-state-management-plugin/src/plugin.rs
+++ b/crates/rock-node-state-management-plugin/src/plugin.rs
@@ -24,6 +24,7 @@ pub struct StateManagementPlugin {
     state_manager: Option<Arc<StateManager>>,
     running: Arc<AtomicBool>,
     shutdown_notify: Arc<Notify>,
+    enabled: bool,
 }
 
 impl Default for StateManagementPlugin {
@@ -39,6 +40,7 @@ impl StateManagementPlugin {
             state_manager: None,
             running: Arc::new(AtomicBool::new(false)),
             shutdown_notify: Arc::new(Notify::new()),
+            enabled: false,
         }
     }
 }
@@ -50,6 +52,14 @@ impl Plugin for StateManagementPlugin {
     }
 
     fn initialize(&mut self, context: AppContext) -> CoreResult<()> {
+        self.enabled = context.config.plugins.state_management_service.enabled;
+
+        if !self.enabled {
+            info!("StateManagementPlugin is disabled via configuration; skipping initialization.");
+            self.app_context = Some(context);
+            return Ok(());
+        }
+
         self.init_internal(context)
             .map_err(|e| CoreError::PluginInitialization(e.to_string()))
     }
@@ -118,6 +128,11 @@ impl StateManagementPlugin {
             .app_context
             .clone()
             .context("AppContext not initialized")?;
+
+        if !self.enabled {
+            info!("StateManagementPlugin start skipped because it is disabled via configuration.");
+            return Ok(());
+        }
 
         // Check if start_block_number is non-zero
         if context.config.core.start_block_number > 0 {
@@ -192,5 +207,86 @@ impl StateManagementPlugin {
             info!("StateManagementPlugin event loop has terminated.");
         });
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rock_node_core::{
+        app_context::AppContext,
+        cache::BlockDataCache,
+        capability::CapabilityRegistry,
+        config::{Config, CoreConfig, PluginConfigs, StateManagementServiceConfig},
+        state_reader::StateReaderProvider,
+        test_utils::create_isolated_metrics,
+    };
+    use std::{
+        any::TypeId,
+        collections::HashMap,
+        sync::{Arc, RwLock},
+    };
+    use tokio::sync::{broadcast, mpsc};
+
+    fn create_test_context(enabled: bool) -> AppContext {
+        let config = Config {
+            core: CoreConfig::default(),
+            plugins: PluginConfigs {
+                state_management_service: StateManagementServiceConfig { enabled },
+                ..Default::default()
+            },
+        };
+
+        AppContext {
+            config: Arc::new(config),
+            metrics: Arc::new(create_isolated_metrics()),
+            capability_registry: Arc::new(CapabilityRegistry::new()),
+            service_providers: Arc::new(RwLock::new(HashMap::new())),
+            block_data_cache: Arc::new(BlockDataCache::new()),
+            tx_block_items_received: mpsc::channel(16).0,
+            tx_block_verified: mpsc::channel(16).0,
+            tx_block_verification_failed: broadcast::channel(16).0,
+            tx_block_persisted: broadcast::channel(16).0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_initialize_disabled_skips_internal_setup() {
+        let ctx = create_test_context(false);
+        let providers = ctx.service_providers.clone();
+
+        let mut plugin = StateManagementPlugin::new();
+        plugin.initialize(ctx.clone()).unwrap();
+
+        assert!(!plugin.enabled, "plugin should record disabled state");
+        assert!(
+            plugin.state_manager.is_none(),
+            "state manager should not be created"
+        );
+        assert!(
+            providers
+                .read()
+                .unwrap()
+                .get(&TypeId::of::<StateReaderProvider>())
+                .is_none(),
+            "StateReaderProvider should not be registered when disabled"
+        );
+        assert!(
+            !plugin.is_running(),
+            "plugin must not be running after initialization"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_start_disabled_does_not_run() {
+        let ctx = create_test_context(false);
+        let mut plugin = StateManagementPlugin::new();
+
+        plugin.initialize(ctx).unwrap();
+        plugin.start().unwrap();
+        assert!(
+            !plugin.is_running(),
+            "plugin should remain stopped when disabled via config"
+        );
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,6 +6,19 @@ events {
     worker_connections 1024;
 }
 
+stream {
+    upstream rock_node_grpc_passthrough {
+        server rock-node:8090;
+    }
+
+    server {
+        listen 6790;
+        proxy_pass rock_node_grpc_passthrough;
+        proxy_connect_timeout 24h;
+        proxy_timeout 24h;
+    }
+}
+
 http {
     client_max_body_size 32m;
 
@@ -15,12 +28,49 @@ http {
     }
 
     server {
-        listen 6790 http2;
+        listen 6791;
+        http2 on;
 
         access_log /var/log/nginx/access.log;
         error_log /var/log/nginx/error.log info;
 
         location /org.hiero.block.api.BlockStreamPublishService {
+            proxy_request_buffering off;
+            grpc_read_timeout 24h;
+            grpc_send_timeout 24h;
+
+            grpc_pass grpc://rock_node_grpc;
+
+            grpc_set_header X-Real-IP $remote_addr;
+            grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            grpc_set_header Host $host;
+        }
+
+        location /org.hiero.block.api.BlockStreamSubscribeService {
+            proxy_request_buffering off;
+            grpc_read_timeout 24h;
+            grpc_send_timeout 24h;
+
+            grpc_pass grpc://rock_node_grpc;
+
+            grpc_set_header X-Real-IP $remote_addr;
+            grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            grpc_set_header Host $host;
+        }
+
+        location /org.hiero.block.api.BlockNodeService {
+            proxy_request_buffering off;
+            grpc_read_timeout 24h;
+            grpc_send_timeout 24h;
+
+            grpc_pass grpc://rock_node_grpc;
+
+            grpc_set_header X-Real-IP $remote_addr;
+            grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            grpc_set_header Host $host;
+        }
+
+        location /org.hiero.block.api.BlockAccessService {
             proxy_request_buffering off;
             grpc_read_timeout 24h;
             grpc_send_timeout 24h;


### PR DESCRIPTION
### Description

Add helm charts

### Related Issues

- Closes #100 
### Changes

Please provide a summary of the changes in this pull request.

- **[Service Name]**: Brief description of change.
- **[File Name]**: Brief description of change.

---
### Reviewer Checklist

- [ ] The code follows the project's coding standards.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added necessary documentation (if applicable).
- [ ] I have confirmed that this change does not introduce any new security vulnerabilities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Helm chart for Kubernetes deployment with configurable plugins and services.
  * Introduced new gRPC service endpoints for BlockStreamSubscribeService, BlockNodeService, and BlockAccessService.
  * Added state management plugin enable/disable toggle.

* **Documentation**
  * Published Helm chart deployment guide with installation, upgrade, and configuration instructions.

* **Bug Fixes**
  * Enhanced readiness checks to verify block reader capability availability before marking service ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->